### PR TITLE
docs(extension): add VS Code extension documentation and update guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,7 @@
-# Contributing
+---
+title: Contributing
+description: "Local development setup, building scripts, and extension development for Skills for Copilot Studio"
+---
 
 ## Local development
 
@@ -24,6 +27,58 @@ npm install
 npm run build
 ```
 
+## VS Code extension development
+
+The VS Code extension packages the same agents, skills, and scripts into a `.vsix` for GitHub Copilot Chat. See [extension/PACKAGING.md](extension/PACKAGING.md) for the complete packaging guide.
+
+### Adding a new agent
+
+1. Create a new `.md` file in `agents/` (e.g., `agents/copilot-studio-myagent.md`)
+2. Include YAML frontmatter with `name`, `description`, and `skills` fields
+3. Add agent instructions in the Markdown body
+
+The packaging script discovers all `.md` files in `agents/` automatically. Each file is renamed to `.agent.md` during staging (VS Code requires this suffix for `contributes.chatAgents`).
+
+### Adding a new skill
+
+1. Create a new directory under `skills/` (e.g., `skills/my-skill/`)
+2. Add a `SKILL.md` file with YAML frontmatter containing `name` and `description`
+3. Optionally add supporting Markdown files in the same directory
+
+The packaging script discovers all directories under `skills/` that contain a `SKILL.md` file and registers them as `contributes.chatSkills` entries. Claude Code-specific frontmatter fields (`allowed-tools`, `context`, `agent`, `argument-hint`, `user-invocable`) are stripped automatically during staging.
+
+### How artifact discovery works
+
+The packaging script (`extension/test-local.sh`) dynamically builds `package.json` at staging time:
+
+1. Scans `agents/` for `.md` files and registers each as a `chatAgents` entry
+2. Scans `skills/` for subdirectories containing `SKILL.md` and registers each as a `chatSkills` entry
+3. Writes the populated `contributes` section into the staged `package.json`
+
+No manual registration is needed. Add a file in the correct location and the build picks it up.
+
+### Testing extension changes locally
+
+```bash
+# Build and install in one step
+bash extension/test-local.sh
+
+# Or package only (no install)
+bash extension/test-local.sh --package-only
+```
+
+After installing, reload VS Code and open Copilot Chat to verify your agents and skills appear.
+
+### Running the CI pipeline locally
+
+The CI workflow runs the same packaging script. To reproduce locally:
+
+```bash
+CODE_CMD="true" bash extension/test-local.sh --package-only
+```
+
+Setting `CODE_CMD="true"` skips the VS Code install step, matching the CI environment.
+
 ## Plugin management
 
 ```bash
@@ -48,10 +103,12 @@ npm run build
 
 ## Project structure
 
-```
+```text
 .claude-plugin/          # Plugin manifest and marketplace config
-.github/plugin/          # GitHub Copilot Plugin manifest to speedup discovery  
-agents/                  # Sub-agent definitions (author, test, troubleshoot)
+.github/plugin/          # GitHub Copilot Plugin manifest to speedup discovery
+.github/workflows/       # CI/CD (build-extension.yml)
+agents/                  # Sub-agent definitions (author, test, troubleshoot, manage)
+extension/               # VS Code extension packaging (test-local.sh, templates, docs)
 hooks/                   # Session hooks (agent routing)
 skills/                  # Skill definitions (entry points + internal skills)
 scripts/                 # Bundled tools (schema lookup, chat-with-agent)

--- a/README.md
+++ b/README.md
@@ -1,23 +1,44 @@
-# Skills for Copilot Studio
+---
+title: Skills for Copilot Studio
+description: "Author, test, and troubleshoot Microsoft Copilot Studio agents through YAML files using a VS Code extension or Claude Code plugin"
+---
 
-A plugin for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and [GitHub Copilot CLI](https://docs.github.com/en/copilot) that enables authoring, testing, and troubleshooting [Microsoft Copilot Studio](https://aka.ms/CopilotStudio) agents through YAML files — directly from your terminal.
+A toolkit for authoring, testing, and troubleshooting [Microsoft Copilot Studio](https://aka.ms/CopilotStudio) agents through YAML files. Available as a VS Code extension for GitHub Copilot Chat and as a plugin for [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
 
 ## Prerequisites
 
-- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [GitHub Copilot CLI](https://docs.github.com/en/copilot)
-- [Node.js](https://nodejs.org/) 18+
-- [VS Code](https://code.visualstudio.com/) with the [Copilot Studio Extension](https://github.com/microsoft/vscode-copilotstudio) (required for push/pull/clone operations)
+* [Node.js](https://nodejs.org/) 18+
+* [VS Code](https://code.visualstudio.com/) with the [Copilot Studio Extension](https://github.com/microsoft/vscode-copilotstudio) (required for push/pull/clone operations)
+* One of the following:
+  * [GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) and [GitHub Copilot Chat](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat) extensions (for the VS Code extension)
+  * [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (for the CLI plugin)
 
 ## Installation
 
-### From marketplace (recommended)
+### VS Code extension (recommended)
+
+Install directly from the VS Code Marketplace:
+
+[Install Copilot Studio Skills](https://marketplace.visualstudio.com/items?itemName=TBD.copilot-studio-skills)
+
+Or from the command line:
+
+```bash
+code --install-extension TBD.copilot-studio-skills
+```
+
+Once installed, the agents and skills are available in GitHub Copilot Chat. See [SETUP_GUIDE.md](SETUP_GUIDE.md) for a full walkthrough.
+
+### Claude Code plugin
+
+#### From marketplace
 
 ```bash
 /plugin marketplace add microsoft/skills-for-copilot-studio
 /plugin install copilot-studio@skills-for-copilot-studio
 ```
 
-### From a local clone
+#### From a local clone
 
 ```bash
 git clone https://github.com/microsoft/skills-for-copilot-studio.git

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -1,26 +1,48 @@
-# Skills for Copilot Studio — Setup Guide
+---
+title: "Skills for Copilot Studio: Setup Guide"
+description: "End-to-end walkthrough for installing the toolkit, cloning an agent, authoring changes, pushing, testing, and troubleshooting"
+---
 
-This guide walks you through setting up the plugin and using it end-to-end: install, clone an agent, author changes, push, test, and troubleshoot.
+This guide walks you through setting up the toolkit and using it end-to-end: install, clone an agent, author changes, push, test, and troubleshoot.
+
+The toolkit is available in two forms:
+
+* **VS Code extension** for GitHub Copilot Chat (recommended for VS Code users)
+* **Claude Code plugin** for terminal-based workflows
 
 ---
 
 ## Prerequisites
 
-| Requirement | Version | Verification |
-|-------------|---------|-------------|
-| Node.js | 18+ | `node --version` |
-| Claude Code or GitHub Copilot CLI | Latest | `claude --version` or equivalent |
-| Copilot Studio VS Code Extension | Latest | [Install from marketplace](https://github.com/microsoft/vscode-copilotstudio) |
-
-The VS Code extension provides the LanguageServerHost binary used for clone, push, and pull operations. VS Code itself does not need to be running.
+| Requirement                         | Version | Verification                                                                                   |
+|-------------------------------------|---------|------------------------------------------------------------------------------------------------|
+| Node.js                             | 18+     | `node --version`                                                                               |
+| VS Code                             | 1.106.1+| Required for the extension; also provides the LSP binary for push/pull/clone                   |
+| Copilot Studio VS Code Extension    | Latest  | [Install from marketplace](https://github.com/microsoft/vscode-copilotstudio)                  |
+| GitHub Copilot + Copilot Chat       | Latest  | Required for the VS Code extension path                                                        |
+| Claude Code or GitHub Copilot CLI   | Latest  | Required for the Claude Code plugin path; `claude --version`                                   |
 
 You also need access to a Power Platform environment with Copilot Studio and an existing agent.
 
 ---
 
-## 1. Install the Plugin
+## 1. Install the Toolkit
 
-### Option A: Install from marketplace (recommended)
+### Option A: VS Code extension (recommended)
+
+Install from the VS Code Marketplace:
+
+[Install Copilot Studio Skills](https://marketplace.visualstudio.com/items?itemName=TBD.copilot-studio-skills)
+
+Or from the command line:
+
+```bash
+code --install-extension TBD.copilot-studio-skills
+```
+
+After installing, reload VS Code. The agents and skills appear in GitHub Copilot Chat.
+
+### Option B: Claude Code plugin from marketplace
 
 ```bash
 /plugin marketplace add microsoft/skills-for-copilot-studio
@@ -29,7 +51,7 @@ You also need access to a Power Platform environment with Copilot Studio and an 
 
 Once installed, the plugin is available globally.
 
-### Option B: Run locally from a clone
+### Option C: Claude Code plugin from a local clone
 
 ```bash
 git clone https://github.com/microsoft/skills-for-copilot-studio.git
@@ -41,19 +63,24 @@ claude --plugin-dir /path/to/skills-for-copilot-studio
 claude plugin install /path/to/skills-for-copilot-studio --scope user
 ```
 
-To verify, type `/` in the input — you should see `copilot-studio:copilot-studio-manage`, `copilot-studio:copilot-studio-author`, `copilot-studio:copilot-studio-test`, and `copilot-studio:copilot-studio-troubleshoot` in the autocomplete menu.
+### Verify installation
+
+* **VS Code extension**: Open Copilot Chat and type `@`. You should see the Copilot Studio agents (Author, Manage, Test, Troubleshoot) in the list.
+* **Claude Code plugin**: Type `/` in the input. You should see `copilot-studio:copilot-studio-manage`, `copilot-studio:copilot-studio-author`, `copilot-studio:copilot-studio-test`, and `copilot-studio:copilot-studio-troubleshoot` in the autocomplete menu.
 
 ---
 
 ## 2. Clone an Agent
 
-### Option A: Clone via the plugin (recommended)
+### Option A: Clone via the Manage agent
 
-```
-/copilot-studio:copilot-studio-manage clone
+In Copilot Chat (VS Code) or Claude Code, ask the Manage agent to clone an agent:
+
+```text
+Clone an agent from Copilot Studio
 ```
 
-This walks you through environment selection, agent selection, and downloads the agent files — all with interactive browser auth (no app registration needed).
+This walks you through environment selection, agent selection, and downloads the agent files with interactive browser auth (no app registration needed).
 
 ### Option B: Clone via VS Code
 
@@ -65,36 +92,42 @@ After cloning, you should see `agent.mcs.yml`, `settings.mcs.yml`, and directori
 
 ## 3. Author Changes
 
-Open Claude Code (or your preferred tool) in the cloned agent's directory.
+Open VS Code (or Claude Code) in the cloned agent's directory.
 
 ### Explore the agent
 
-```
-/copilot-studio:copilot-studio-author What topics does this agent have? Give me an overview.
+Ask the Author agent to describe the agent:
+
+```text
+What topics does this agent have? Give me an overview.
 ```
 
 ### Create a new topic
 
-```
-/copilot-studio:copilot-studio-author Create a new topic called "Product Information" that responds to questions about our products with a message listing our top 3 products.
+```text
+Create a new topic called "Product Information" that responds to questions about our products with a message listing our top 3 products.
 ```
 
-The agent generates a valid YAML file with unique IDs and saves it to the `topics/` directory.
+The Author agent generates a valid YAML file with unique IDs and saves it to the `topics/` directory.
 
 ### Validate your changes
 
-```
-/copilot-studio:copilot-studio-troubleshoot Validate all topics in my agent
+Ask the Troubleshoot agent to validate:
+
+```text
+Validate all topics in my agent
 ```
 
 ---
 
 ## 4. Push and Publish
 
-### Push via the plugin (recommended)
+### Push via the Manage agent (recommended)
 
-```
-/copilot-studio:copilot-studio-manage push
+Ask the Manage agent to push:
+
+```text
+Push my changes to Copilot Studio
 ```
 
 A browser window may open for sign-in on first use. Tokens are cached after that.
@@ -111,43 +144,45 @@ Alternatively, use the Copilot Studio VS Code Extension:
 After pushing, **publish** in the Copilot Studio UI at [copilotstudio.microsoft.com](https://copilotstudio.microsoft.com):
 - Open your agent and click **Publish**
 
-> **Important**: Pushing creates a **draft**. You must also **publish** to make changes live and testable via the plugin.
+> [!IMPORTANT]
+> Pushing creates a **draft**. You must also **publish** to make changes live and testable.
 
 ---
 
 ## 5. Test the Published Agent
 
-The test agent (`/copilot-studio:copilot-studio-test`) supports three ways to test:
+The Test agent supports three ways to test:
 
 ### Option A: Send a test message (point-test)
 
 Send a single utterance directly to the published agent and see its full response. Requires an **Azure App Registration**:
-- **Platform**: Public client / Native (Mobile and desktop applications)
-- **Redirect URI**: `http://localhost` (HTTP, not HTTPS)
-- **API permissions**: Add a permission → APIs my organization uses → search **Power Platform API** → Delegated permissions → expand CopilotStudio → check `CopilotStudio.Copilots.Invoke` (optionally grant admin consent)
 
-```
-/copilot-studio:copilot-studio-test Send "What products do you offer?" to the published agent
+* **Platform**: Public client / Native (Mobile and desktop applications)
+* **Redirect URI**: `http://localhost` (HTTP, not HTTPS)
+* **API permissions**: Add a permission, then APIs my organization uses, search **Power Platform API**, Delegated permissions, expand CopilotStudio, check `CopilotStudio.Copilots.Invoke` (optionally grant admin consent)
+
+```text
+Send "What products do you offer?" to the published agent
 ```
 
-The test agent will ask for your App Registration Client ID on first use, authenticate via device code flow, and return the agent's full response. Multi-turn is supported — the agent reuses the conversation automatically.
+The Test agent asks for your App Registration Client ID on first use, authenticates via device code flow, and returns the agent's full response. Multi-turn is supported; the agent reuses the conversation automatically.
 
 ### Option B: Run a batch test suite (Copilot Studio Kit)
 
 If you have the [Power CAT Copilot Studio Kit](https://github.com/microsoft/Power-CAT-Copilot-Studio-Kit) installed in your environment, you can run pre-defined test sets with expected responses and pass/fail scoring. Requires an Azure App Registration with Dataverse permissions.
 
-```
-/copilot-studio:copilot-studio-test Run my test suite
+```text
+Run my test suite
 ```
 
-The agent walks you through configuring the Dataverse connection on first use.
+The Test agent walks you through configuring the Dataverse connection on first use.
 
 ### Option C: Analyze evaluation results
 
 Run evaluations in the Copilot Studio UI, export the results as CSV, and have the agent analyze failures and propose fixes:
 
-```
-/copilot-studio:copilot-studio-test Analyze my evaluation results from ~/Downloads/Evaluate MyAgent.csv
+```text
+Analyze my evaluation results from ~/Downloads/Evaluate MyAgent.csv
 ```
 
 ---
@@ -156,14 +191,14 @@ Run evaluations in the Copilot Studio UI, export the results as CSV, and have th
 
 If the agent responds with incorrect or outdated information:
 
-```
-/copilot-studio:copilot-studio-troubleshoot The agent is making up product details that aren't accurate. It seems to be hallucinating instead of using real data.
+```text
+The agent is making up product details that aren't accurate. It seems to be hallucinating instead of using real data.
 ```
 
-The troubleshoot agent will diagnose the issue — in this case, the agent is generating ungrounded responses because it has no knowledge source to draw from. Fix it by adding one:
+The Troubleshoot agent diagnoses the issue. In this case, the agent is generating ungrounded responses because it has no knowledge source to draw from. Fix it by asking the Author agent:
 
-```
-/copilot-studio:copilot-studio-author Add a knowledge source pointing to our product catalog at https://contoso.com/products
+```text
+Add a knowledge source pointing to our product catalog at https://contoso.com/products
 ```
 
 Then push, publish, and test again to verify the agent now responds with grounded information.
@@ -172,28 +207,29 @@ Then push, publish, and test again to verify the agent now responds with grounde
 
 ## Troubleshooting
 
-| Issue | Possible Cause | Solution |
-|-------|---------------|----------|
-| Schema lookup returns "not found" | Definition name case mismatch | Use `search` to find the correct name |
-| YAML parse error on import | Invalid YAML syntax | Check for indentation issues, missing colons |
-| Topic doesn't render in canvas | Complex YAML not supported | Simplify the structure, use portal for complex edits |
-| Duplicate ID error | Non-unique node IDs | Regenerate IDs for copied nodes |
-| Power Fx error | Missing `=` prefix | Ensure expressions start with `=` |
-| Plugin not found | Not installed or wrong path | Run `/plugin list` to verify |
-| Extension not found (clone/push/pull) | Copilot Studio VS Code Extension not installed | [Install from marketplace](https://github.com/microsoft/vscode-copilotstudio) |
-| ConcurrencyVersionMismatch on push | Stale row versions | Pull first, then push |
+| Issue                                  | Possible cause                                    | Solution                                                                        |
+|----------------------------------------|---------------------------------------------------|---------------------------------------------------------------------------------|
+| Schema lookup returns "not found"      | Definition name case mismatch                     | Use `search` to find the correct name                                           |
+| YAML parse error on import             | Invalid YAML syntax                               | Check for indentation issues, missing colons                                    |
+| Topic doesn't render in canvas         | Complex YAML not supported                        | Simplify the structure, use portal for complex edits                            |
+| Duplicate ID error                     | Non-unique node IDs                               | Regenerate IDs for copied nodes                                                 |
+| Power Fx error                         | Missing `=` prefix                                | Ensure expressions start with `=`                                               |
+| Plugin not found                       | Not installed or wrong path                       | Run `/plugin list` to verify                                                    |
+| Agents not visible in Copilot Chat     | Extension not installed or not activated          | Install the extension and reload VS Code                                        |
+| Extension not found (clone/push/pull)  | Copilot Studio VS Code Extension not installed    | [Install from marketplace](https://github.com/microsoft/vscode-copilotstudio)  |
+| ConcurrencyVersionMismatch on push     | Stale row versions                                | Pull first, then push                                                           |
 
-If something goes wrong, you can always re-clone the original agent with `/copilot-studio:copilot-studio-manage clone` or the VS Code Extension.
+If something goes wrong, you can always re-clone the original agent using the Manage agent or the Copilot Studio VS Code Extension.
 
 ---
 
 ## Summary Checklist
 
-- [ ] Plugin installed from marketplace or loaded locally
-- [ ] Copilot Studio VS Code Extension installed (provides the LSP binary)
-- [ ] Agent cloned with `/copilot-studio:copilot-studio-manage clone` or VS Code Extension
-- [ ] `/copilot-studio:copilot-studio-manage`, `:copilot-studio-author`, `:copilot-studio-test`, `:copilot-studio-troubleshoot` visible in `/` autocomplete
-- [ ] Created a topic with `/copilot-studio:copilot-studio-author`
-- [ ] Validated with `/copilot-studio:copilot-studio-troubleshoot`
-- [ ] Pulled, pushed, and published (`/copilot-studio:copilot-studio-manage pull`, then `push`)
-- [ ] Tested published agent with `/copilot-studio:copilot-studio-test`
+* [ ] Toolkit installed (VS Code extension or Claude Code plugin)
+* [ ] Copilot Studio VS Code Extension installed (provides the LSP binary for push/pull/clone)
+* [ ] Agent cloned using the Manage agent or VS Code Extension
+* [ ] Agents visible in Copilot Chat (`@` menu) or Claude Code (`/` autocomplete)
+* [ ] Created a topic with the Author agent
+* [ ] Validated with the Troubleshoot agent
+* [ ] Pulled, pushed, and published
+* [ ] Tested published agent with the Test agent

--- a/extension/PACKAGING.md
+++ b/extension/PACKAGING.md
@@ -1,0 +1,162 @@
+---
+title: Extension Packaging Guide
+description: "How to build, package, test, and publish the Copilot Studio Skills VS Code extension"
+author: Microsoft
+ms.date: 2026-03-27
+ms.topic: how-to
+---
+
+## Overview
+
+The VS Code extension packages the same agents, skills, scripts, templates, and reference files used by the Claude Code plugin into a `.vsix` file for GitHub Copilot Chat.
+
+The packaging pipeline is a single Bash script (`extension/test-local.sh`) that stages artifacts, transforms platform-specific constructs, generates `package.json`, and invokes `vsce` to produce the VSIX.
+
+### Extension structure
+
+```text
+extension/
+  .staging/             # Generated staging directory (git-ignored)
+  docs/adr/             # Architecture decision records
+  templates/
+    package.template.json   # Base package.json for the extension
+  icon.png              # Marketplace icon
+  LICENSE               # Extension license
+  README.md             # Marketplace README (rendered on the extension page)
+  test-local.sh         # Build and install script
+```
+
+After packaging, the staging directory contains the final extension layout:
+
+```text
+.staging/
+  agents/               # Agent files renamed to .agent.md
+  skills/               # Skill files with Claude Code frontmatter stripped
+  scripts/              # Bundled Node.js scripts (.bundle.js only)
+  templates/            # YAML templates for common patterns
+  reference/            # Schema and connector files
+  package.json          # Generated with discovered agents and skills
+  README.md             # Frontmatter-stripped copy of extension/README.md
+  icon.png              # Marketplace icon
+  LICENSE               # License file
+```
+
+### What the build script does
+
+1. Copies agent files from `agents/`, renaming `.md` to `.agent.md` (VS Code requires this suffix)
+2. Copies skill files from `skills/` and strips Claude Code-specific frontmatter fields (`allowed-tools`, `context`, `agent`, `argument-hint`, `user-invocable`)
+3. Copies `scripts/`, `templates/`, and `reference/` directories
+4. Generates `package.json` from the template, populating `contributes.chatAgents` and `contributes.chatSkills` by discovering staged files
+5. Resolves `${CLAUDE_SKILL_DIR}/../../` path references to relative `../../` paths
+6. Strips YAML frontmatter from the extension README (VS Code renders frontmatter as visible text)
+7. Packages everything with `vsce` into a `.vsix` file
+
+## Prerequisites
+
+| Requirement | Version   | Installation                                       |
+|-------------|-----------|----------------------------------------------------|
+| Node.js     | 18+       | <https://nodejs.org/>                              |
+| npm         | Bundled   | Included with Node.js                              |
+| VS Code     | 1.106.1+  | <https://code.visualstudio.com/>                   |
+| Bash        | 4+        | Pre-installed on macOS/Linux; use Git Bash on Windows |
+
+The `vsce` CLI is fetched automatically via `npx` during packaging. No global install is needed.
+
+## Build and package
+
+### Package the extension
+
+Run the build script with the `--package-only` flag to produce the VSIX without installing:
+
+```bash
+bash extension/test-local.sh --package-only
+```
+
+The VSIX file is written to `extension/copilot-studio-skills-<version>.vsix`.
+
+### Build and install locally
+
+Run the script without flags to package and install in one step:
+
+```bash
+bash extension/test-local.sh
+```
+
+This packages the extension and then runs `code --install-extension` to install it. Reload VS Code to activate.
+
+> [!TIP]
+> Set the `CODE_CMD` environment variable to point to a specific VS Code binary if `code` is not on your PATH:
+>
+> ```bash
+> CODE_CMD="/path/to/code" bash extension/test-local.sh
+> ```
+
+### Uninstall
+
+```bash
+code --uninstall-extension TBD.copilot-studio-skills
+```
+
+## CI/CD pipeline
+
+The GitHub Actions workflow at `.github/workflows/build-extension.yml` runs on every push and pull request that touches agent, skill, script, template, reference, or extension files.
+
+The pipeline:
+
+1. Checks out the repository
+2. Sets up Node.js 20
+3. Runs `bash extension/test-local.sh --package-only` (with `CODE_CMD=true` to skip VS Code install)
+4. Verifies a VSIX file was produced
+5. Uploads the VSIX as a build artifact (retained for 30 days)
+
+## Publishing to the Marketplace
+
+> [!IMPORTANT]
+> The extension publisher is currently set to `TBD` in `extension/templates/package.template.json`. Update the `publisher` field before publishing.
+
+### First-time setup
+
+1. Create a publisher on the [VS Code Marketplace](https://marketplace.visualstudio.com/manage)
+2. Generate a Personal Access Token (PAT) with the **Marketplace (Manage)** scope
+3. Update `publisher` in `extension/templates/package.template.json` to match your publisher ID
+
+### Publish
+
+```bash
+# Package first
+bash extension/test-local.sh --package-only
+
+# Publish the VSIX
+cd extension/.staging
+npx @vscode/vsce publish --pat <YOUR_PAT>
+```
+
+Alternatively, upload the VSIX manually through the [Marketplace management portal](https://marketplace.visualstudio.com/manage).
+
+## Version management
+
+The extension version is defined in `extension/templates/package.template.json` in the `version` field.
+
+To bump the version:
+
+1. Update the `version` field in `extension/templates/package.template.json`
+2. Rebuild with `bash extension/test-local.sh --package-only`
+3. Commit the template change
+
+The version follows [SemVer](https://semver.org/):
+
+* Increment the **major** version for breaking changes to agent or skill interfaces
+* Increment the **minor** version when adding new agents, skills, or templates
+* Increment the **patch** version for bug fixes and documentation updates
+
+## Troubleshooting
+
+| Issue                           | Cause                                      | Solution                                                                 |
+|---------------------------------|--------------------------------------------|--------------------------------------------------------------------------|
+| `No .vsix file produced`       | `vsce` packaging failed                    | Check the script output for errors; verify Node.js 18+ is installed      |
+| Extension not visible in Chat   | Extension not activated after install      | Reload VS Code (`Developer: Reload Window`)                              |
+| Agents or skills missing        | Files not discovered during staging        | Verify agent files exist in `agents/` and skill folders contain `SKILL.md` |
+| `icon` field error from `vsce` | `icon.png` missing from `extension/`       | Add an `icon.png` or remove the `icon` field from the template          |
+| Frontmatter visible in README   | YAML frontmatter not stripped              | Re-run `test-local.sh` to regenerate the staged README                  |
+| `command not found: code`      | VS Code CLI not on PATH                    | Set `CODE_CMD` or install the `code` command from VS Code Command Palette |
+| Publisher rejected              | `publisher` still set to `TBD`             | Update the publisher in `package.template.json` before publishing        |


### PR DESCRIPTION
## Summary

Added extension packaging documentation and updated the root community files (README, CONTRIBUTING, SETUP_GUIDE) to cover the VS Code extension as a first-class installation path alongside the Claude Code plugin.

## Changes

### New documentation

- Created **extension/PACKAGING.md** with a complete developer guide covering extension structure, build prerequisites, packaging commands, CI/CD pipeline, Marketplace publishing, version management, and troubleshooting.

### Updated community files

- Updated *README.md* to present the **VS Code extension** as the recommended installation method, with the Claude Code plugin as an alternative. Restructured prerequisites to list both paths clearly.
- Updated *CONTRIBUTING.md* with a new extension development section covering how to add agents and skills, how artifact discovery works during packaging, how to test locally, and how to reproduce the CI pipeline.
- Updated *SETUP_GUIDE.md* to be platform-neutral. All walkthrough steps now use agent names instead of Claude Code-specific slash commands. Installation section offers VS Code extension, Claude Code marketplace, and local clone as three options.

### Frontmatter

- Added YAML frontmatter (`title`, `description`) to *README.md*, *CONTRIBUTING.md*, and *SETUP_GUIDE.md* to comply with markdown instructions. Removed H1 headings since the frontmatter `title` field serves as the document title.

## Related Issues

Closes #7

## Follow-up Tasks

- Update `publisher` field in `extension/templates/package.template.json` (currently `TBD`) before Marketplace publishing.
- Add Marketplace badges to README once the extension is published.
