### PR TITLE
feat(workflows): add CI/CD publish workflow and marketplace metadata

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -21,6 +21,12 @@ on:
       - 'reference/**'
       - 'extension/**'
       - '.github/workflows/build-extension.yml'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version override (e.g. 0.2.0). Leave empty to use package.template.json version.'
+        required: false
+        type: string
 
 jobs:
   lint-scripts:
@@ -72,6 +78,18 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
+
+      - name: Override version
+        if: inputs.version != ''
+        run: |
+          cd extension/templates
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.template.json', 'utf8'));
+            pkg.version = '${{ inputs.version }}';
+            fs.writeFileSync('package.template.json', JSON.stringify(pkg, null, 2) + '\n');
+            console.log('Version set to: ' + pkg.version);
+          "
 
       - name: Build extension
         run: bash extension/test-local.sh --package-only

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -10,6 +10,7 @@ on:
       - 'templates/**'
       - 'reference/**'
       - 'extension/**'
+      - 'extension-pack/**'
       - '.github/workflows/build-extension.yml'
   pull_request:
     branches: [main, coatsy/vscode-extension]
@@ -20,6 +21,7 @@ on:
       - 'templates/**'
       - 'reference/**'
       - 'extension/**'
+      - 'extension-pack/**'
       - '.github/workflows/build-extension.yml'
   workflow_dispatch:
     inputs:
@@ -44,7 +46,7 @@ jobs:
       - name: Validate shell script syntax
         run: |
           errors=0
-          for script in extension/*.sh; do
+          for script in extension/*.sh extension-pack/*.sh; do
             echo "Checking $script..."
             if ! bash -n "$script"; then
               errors=$((errors + 1))
@@ -58,7 +60,7 @@ jobs:
       - name: Run ShellCheck
         run: |
           errors=0
-          for script in extension/*.sh; do
+          for script in extension/*.sh extension-pack/*.sh; do
             echo "Checking $script..."
             if ! shellcheck --severity=warning "$script"; then
               errors=$((errors + 1))
@@ -140,9 +142,31 @@ jobs:
 
           echo "VSIX validation passed: $AGENTS agents, $SKILLS skills"
 
-      - name: Upload VSIX
+      - name: Upload skills extension VSIX
         uses: actions/upload-artifact@v4
         with:
           name: copilot-studio-skills-vsix
           path: extension/*.vsix
+          retention-days: 30
+
+      - name: Build extension pack
+        run: bash extension-pack/build.sh --package-only
+        env:
+          CODE_CMD: 'true'
+
+      - name: Verify extension pack VSIX
+        run: |
+          VSIX=$(ls -t extension-pack/*.vsix 2>/dev/null | head -1)
+          if [ -z "$VSIX" ]; then
+            echo "ERROR: No extension pack .vsix file produced"
+            exit 1
+          fi
+          echo "Built: $VSIX"
+          echo "Size: $(du -h "$VSIX" | cut -f1)"
+
+      - name: Upload extension pack VSIX
+        uses: actions/upload-artifact@v4
+        with:
+          name: copilot-studio-bundle-vsix
+          path: extension-pack/*.vsix
           retention-days: 30

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -1,0 +1,80 @@
+name: Publish Extension
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run \u2014 package without publishing'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Resolve version from release tag
+        if: github.event_name == 'release'
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          # Strip leading 'v' if present
+          VERSION="${TAG#v}"
+          echo "RELEASE_VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "Resolved version from tag: $VERSION"
+
+      - name: Validate version matches manifest
+        if: github.event_name == 'release'
+        run: |
+          MANIFEST_VERSION=$(node -e "
+            const pkg = require('./extension/templates/package.template.json');
+            console.log(pkg.version);
+          ")
+          echo "Manifest version: $MANIFEST_VERSION"
+          echo "Release version:  $RELEASE_VERSION"
+          if [ "$MANIFEST_VERSION" != "$RELEASE_VERSION" ]; then
+            echo "ERROR: Version mismatch \u2014 manifest ($MANIFEST_VERSION) does not match release tag ($RELEASE_VERSION)"
+            echo "Update the version in extension/templates/package.template.json before releasing."
+            exit 1
+          fi
+
+      - name: Build VSIX
+        run: bash extension/test-local.sh --package-only
+        env:
+          CODE_CMD: 'true'
+
+      - name: Verify VSIX artifact
+        run: |
+          VSIX=$(ls -t extension/*.vsix 2>/dev/null | head -1)
+          if [ -z "$VSIX" ]; then
+            echo "ERROR: No .vsix file produced"
+            exit 1
+          fi
+          echo "VSIX_PATH=$VSIX" >> "$GITHUB_ENV"
+          echo "Built: $VSIX ($(du -h "$VSIX" | cut -f1))"
+
+      - name: Publish to VS Code Marketplace
+        if: >-
+          (github.event_name == 'release' ||
+           (github.event_name == 'workflow_dispatch' && inputs.dry_run == false))
+        run: npx --yes @vscode/vsce publish --no-dependencies --packagePath "$VSIX_PATH"
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Dry-run notice
+        if: github.event_name == 'workflow_dispatch' && inputs.dry_run == true
+        run: echo "Dry run \u2014 VSIX built but not published."
+
+      - name: Upload VSIX
+        uses: actions/upload-artifact@v4
+        with:
+          name: copilot-studio-skills-vsix
+          path: extension/*.vsix
+          retention-days: 30

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -30,51 +30,89 @@ jobs:
           echo "RELEASE_VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "Resolved version from tag: $VERSION"
 
-      - name: Validate version matches manifest
+      - name: Validate version matches manifests
         if: github.event_name == 'release'
         run: |
-          MANIFEST_VERSION=$(node -e "
+          SKILLS_VERSION=$(node -e "
             const pkg = require('./extension/templates/package.template.json');
             console.log(pkg.version);
           ")
-          echo "Manifest version: $MANIFEST_VERSION"
-          echo "Release version:  $RELEASE_VERSION"
-          if [ "$MANIFEST_VERSION" != "$RELEASE_VERSION" ]; then
-            echo "ERROR: Version mismatch \u2014 manifest ($MANIFEST_VERSION) does not match release tag ($RELEASE_VERSION)"
-            echo "Update the version in extension/templates/package.template.json before releasing."
+          BUNDLE_VERSION=$(node -e "
+            const pkg = require('./extension-pack/package.json');
+            console.log(pkg.version);
+          ")
+          echo "Skills extension version: $SKILLS_VERSION"
+          echo "Extension pack version:   $BUNDLE_VERSION"
+          echo "Release version:          $RELEASE_VERSION"
+          if [ "$SKILLS_VERSION" != "$RELEASE_VERSION" ]; then
+            echo "ERROR: Skills extension version ($SKILLS_VERSION) does not match release tag ($RELEASE_VERSION)"
+            exit 1
+          fi
+          if [ "$BUNDLE_VERSION" != "$RELEASE_VERSION" ]; then
+            echo "ERROR: Extension pack version ($BUNDLE_VERSION) does not match release tag ($RELEASE_VERSION)"
             exit 1
           fi
 
-      - name: Build VSIX
+      - name: Build skills extension VSIX
         run: bash extension/test-local.sh --package-only
         env:
           CODE_CMD: 'true'
 
-      - name: Verify VSIX artifact
+      - name: Verify skills extension VSIX
         run: |
           VSIX=$(ls -t extension/*.vsix 2>/dev/null | head -1)
           if [ -z "$VSIX" ]; then
-            echo "ERROR: No .vsix file produced"
+            echo "ERROR: No skills extension .vsix file produced"
             exit 1
           fi
-          echo "VSIX_PATH=$VSIX" >> "$GITHUB_ENV"
+          echo "SKILLS_VSIX=$VSIX" >> "$GITHUB_ENV"
           echo "Built: $VSIX ($(du -h "$VSIX" | cut -f1))"
 
-      - name: Publish to VS Code Marketplace
+      - name: Build extension pack
+        run: bash extension-pack/build.sh --package-only
+        env:
+          CODE_CMD: 'true'
+
+      - name: Verify extension pack VSIX
+        run: |
+          VSIX=$(ls -t extension-pack/*.vsix 2>/dev/null | head -1)
+          if [ -z "$VSIX" ]; then
+            echo "ERROR: No extension pack .vsix file produced"
+            exit 1
+          fi
+          echo "BUNDLE_VSIX=$VSIX" >> "$GITHUB_ENV"
+          echo "Built: $VSIX ($(du -h "$VSIX" | cut -f1))"
+
+      - name: Publish skills extension to Marketplace
         if: >-
           (github.event_name == 'release' ||
            (github.event_name == 'workflow_dispatch' && inputs.dry_run == false))
-        run: npx --yes @vscode/vsce publish --no-dependencies --packagePath "$VSIX_PATH"
+        run: npx --yes @vscode/vsce publish --no-dependencies --packagePath "$SKILLS_VSIX"
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Publish extension pack to Marketplace
+        if: >-
+          (github.event_name == 'release' ||
+           (github.event_name == 'workflow_dispatch' && inputs.dry_run == false))
+        run: npx --yes @vscode/vsce publish --no-dependencies --packagePath "$BUNDLE_VSIX"
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
       - name: Dry-run notice
         if: github.event_name == 'workflow_dispatch' && inputs.dry_run == true
-        run: echo "Dry run \u2014 VSIX built but not published."
+        run: echo "Dry run \u2014 both VSIX files built but not published."
 
-      - name: Upload VSIX
+      - name: Upload skills extension VSIX
         uses: actions/upload-artifact@v4
         with:
           name: copilot-studio-skills-vsix
           path: extension/*.vsix
+          retention-days: 30
+
+      - name: Upload extension pack VSIX
+        uses: actions/upload-artifact@v4
+        with:
+          name: copilot-studio-bundle-vsix
+          path: extension-pack/*.vsix
           retention-days: 30

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -30,18 +30,26 @@ jobs:
           echo "RELEASE_VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "Resolved version from tag: $VERSION"
 
-      - name: Validate version matches manifest
+      - name: Validate version matches manifests
         if: github.event_name == 'release'
         run: |
-          MANIFEST_VERSION=$(node -e "
+          SKILLS_VERSION=$(node -e "
             const pkg = require('./extension/templates/package.template.json');
             console.log(pkg.version);
           ")
-          echo "Manifest version: $MANIFEST_VERSION"
-          echo "Release version:  $RELEASE_VERSION"
-          if [ "$MANIFEST_VERSION" != "$RELEASE_VERSION" ]; then
-            echo "ERROR: Version mismatch \u2014 manifest ($MANIFEST_VERSION) does not match release tag ($RELEASE_VERSION)"
-            echo "Update the version in extension/templates/package.template.json before releasing."
+          BUNDLE_VERSION=$(node -e "
+            const pkg = require('./extension-pack/package.json');
+            console.log(pkg.version);
+          ")
+          echo "Skills extension version: $SKILLS_VERSION"
+          echo "Extension pack version:   $BUNDLE_VERSION"
+          echo "Release version:          $RELEASE_VERSION"
+          if [ "$SKILLS_VERSION" != "$RELEASE_VERSION" ]; then
+            echo "ERROR: Skills extension version ($SKILLS_VERSION) does not match release tag ($RELEASE_VERSION)"
+            exit 1
+          fi
+          if [ "$BUNDLE_VERSION" != "$RELEASE_VERSION" ]; then
+            echo "ERROR: Extension pack version ($BUNDLE_VERSION) does not match release tag ($RELEASE_VERSION)"
             exit 1
           fi
 
@@ -50,31 +58,61 @@ jobs:
         env:
           CODE_CMD: 'true'
 
-      - name: Verify VSIX artifact
+      - name: Verify skills extension VSIX
         run: |
           VSIX=$(ls -t extension/*.vsix 2>/dev/null | head -1)
           if [ -z "$VSIX" ]; then
-            echo "ERROR: No .vsix file produced"
+            echo "ERROR: No skills extension .vsix file produced"
             exit 1
           fi
-          echo "VSIX_PATH=$VSIX" >> "$GITHUB_ENV"
+          echo "SKILLS_VSIX=$VSIX" >> "$GITHUB_ENV"
           echo "Built: $VSIX ($(du -h "$VSIX" | cut -f1))"
 
-      - name: Publish to VS Code Marketplace
+      - name: Build extension pack
+        run: bash extension-pack/build.sh --package-only
+        env:
+          CODE_CMD: 'true'
+
+      - name: Verify extension pack VSIX
+        run: |
+          VSIX=$(ls -t extension-pack/*.vsix 2>/dev/null | head -1)
+          if [ -z "$VSIX" ]; then
+            echo "ERROR: No extension pack .vsix file produced"
+            exit 1
+          fi
+          echo "BUNDLE_VSIX=$VSIX" >> "$GITHUB_ENV"
+          echo "Built: $VSIX ($(du -h "$VSIX" | cut -f1))"
+
+      - name: Publish skills extension to Marketplace
         if: >-
           (github.event_name == 'release' ||
            (github.event_name == 'workflow_dispatch' && inputs.dry_run == false))
-        run: npx --yes @vscode/vsce publish --no-dependencies --packagePath "$VSIX_PATH"
+        run: npx --yes @vscode/vsce publish --no-dependencies --packagePath "$SKILLS_VSIX"
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Publish extension pack to Marketplace
+        if: >-
+          (github.event_name == 'release' ||
+           (github.event_name == 'workflow_dispatch' && inputs.dry_run == false))
+        run: npx --yes @vscode/vsce publish --no-dependencies --packagePath "$BUNDLE_VSIX"
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
       - name: Dry-run notice
         if: github.event_name == 'workflow_dispatch' && inputs.dry_run == true
-        run: echo "Dry run \u2014 VSIX built but not published."
+        run: echo "Dry run — both VSIX files built but not published."
 
-      - name: Upload VSIX
+      - name: Upload skills extension VSIX
         uses: actions/upload-artifact@v4
         with:
           name: copilot-studio-skills-vsix
           path: extension/*.vsix
+          retention-days: 30
+
+      - name: Upload extension pack VSIX
+        uses: actions/upload-artifact@v4
+        with:
+          name: copilot-studio-bundle-vsix
+          path: extension-pack/*.vsix
           retention-days: 30

--- a/extension/PACKAGING.md
+++ b/extension/PACKAGING.md
@@ -54,7 +54,7 @@ After packaging, the staging directory contains the final extension layout:
 ## Prerequisites
 
 | Requirement | Version   | Installation                                       |
-|-------------|-----------|----------------------------------------------------|
+|-------------|-----------|----------------------------------------------------||
 | Node.js     | 22+       | <https://nodejs.org/>                              |
 | npm         | Bundled   | Included with Node.js                              |
 | VS Code     | 1.106.1+  | <https://code.visualstudio.com/>                   |
@@ -118,16 +118,19 @@ For launch.json configurations and debugger attachment, see [Debug Configuration
 
 ## CI/CD pipeline
 
-The GitHub Actions workflow at `.github/workflows/build-extension.yml` runs on every push and pull request that touches agent, skill, script, template, reference, or extension files.
+The GitHub Actions workflow at `.github/workflows/build-extension.yml` runs on every push and pull request that touches agent, skill, script, template, reference, or extension files. It can also be triggered manually via `workflow_dispatch` with an optional version override.
 
 The pipeline:
 
 1. Checks out the repository
 2. Sets up Node.js 22
-3. Runs `bash extension/test-local.sh --package-only` (with `CODE_CMD=true` to skip VS Code install)
-4. Verifies a VSIX file was produced
-5. Validates VSIX contents (agent/skill counts, no Claude-specific fields, required directories)
-6. Uploads the VSIX as a build artifact (retained for 30 days)
+3. Applies the version override if provided (manual dispatch only)
+4. Runs `bash extension/test-local.sh --package-only` (with `CODE_CMD=true` to skip VS Code install)
+5. Verifies a VSIX file was produced
+6. Validates VSIX contents (agent/skill counts, no Claude-specific fields, required directories)
+7. Uploads the VSIX as a build artifact (retained for 30 days)
+
+A separate publish workflow at `.github/workflows/publish-extension.yml` handles Marketplace publishing. It triggers on GitHub Release creation or manual dispatch and supports a dry-run mode for testing without publishing.
 
 ## Publishing to the Marketplace
 
@@ -137,10 +140,27 @@ The pipeline:
 ### First-time setup
 
 1. Create a publisher on the [VS Code Marketplace](https://marketplace.visualstudio.com/manage)
-2. Generate a Personal Access Token (PAT) with the **Marketplace (Manage)** scope
+2. Generate a Personal Access Token (PAT) with the **Marketplace (Manage)** scope:
+   1. Go to [Azure DevOps](https://dev.azure.com)
+   2. Open **User settings** (top-right gear) → **Personal access tokens** → **New Token**
+   3. Set the organization to **All accessible organizations**
+   4. Under **Scopes**, select **Custom defined** and check **Marketplace > Manage**
+   5. Copy the generated token
 3. Update `publisher` in `extension/templates/package.template.json` to match your publisher ID
 
-### Publish
+### Setting up `VSCE_PAT` for CI/CD
+
+The publish workflow (`.github/workflows/publish-extension.yml`) requires a `VSCE_PAT` repository secret:
+
+1. Generate a PAT using the steps above
+2. In your GitHub repository, go to **Settings** → **Secrets and variables** → **Actions**
+3. Click **New repository secret**
+4. Name: `VSCE_PAT`, Value: paste the PAT
+5. Click **Add secret**
+
+The publish workflow triggers automatically when a GitHub Release is created. Manual dispatch is also available with an optional dry-run mode.
+
+### Publish manually
 
 ```bash
 # Package first
@@ -152,6 +172,17 @@ npx @vscode/vsce publish --pat <YOUR_PAT>
 ```
 
 Alternatively, upload the VSIX manually through the [Marketplace management portal](https://marketplace.visualstudio.com/manage).
+
+### Publish via CI/CD
+
+The automated workflow handles publishing on release:
+
+1. Update the `version` in `extension/templates/package.template.json`
+2. Commit and push to the default branch
+3. Create a GitHub Release with a tag matching the version (e.g., `v0.2.0`)
+4. The workflow builds the VSIX, validates the version matches, and publishes
+
+To test without publishing, use the **Run workflow** button on the Actions tab and check the **Dry run** option.
 
 ## Version management
 
@@ -172,7 +203,7 @@ The version follows [SemVer](https://semver.org/):
 ## Troubleshooting
 
 | Issue                           | Cause                                      | Solution                                                                 |
-|---------------------------------|--------------------------------------------|--------------------------------------------------------------------------|
+|---------------------------------|--------------------------------------------|---------------------------------------------------------------------------|
 | `No .vsix file produced`       | `vsce` packaging failed                    | Check the script output for errors; verify Node.js 22+ is installed      |
 | Extension not visible in Chat   | Extension not activated after install      | Reload VS Code (`Developer: Reload Window`)                              |
 | Agents or skills missing        | Files not discovered during staging        | Verify agent files exist in `agents/` and skill folders contain `SKILL.md` |

--- a/extension/templates/package.template.json
+++ b/extension/templates/package.template.json
@@ -12,12 +12,27 @@
     "type": "git",
     "url": "https://github.com/microsoft/skills-for-copilot-studio.git"
   },
+  "bugs": {
+    "url": "https://github.com/microsoft/skills-for-copilot-studio/issues"
+  },
+  "homepage": "https://github.com/microsoft/skills-for-copilot-studio#readme",
   "engines": {
     "vscode": "^1.106.1"
   },
   "categories": [
     "Chat"
   ],
+  "keywords": [
+    "copilot",
+    "copilot-studio",
+    "agents",
+    "skills",
+    "yaml"
+  ],
+  "galleryBanner": {
+    "color": "#1e1e1e",
+    "theme": "dark"
+  },
   "icon": "icon.png",
   "contributes": {},
   "author": "Microsoft",


### PR DESCRIPTION
## Summary

Add CI/CD publish workflow and marketplace metadata for the VS Code extension.

## Changes

### Issue #5 — CI/CD workflows
- Added `workflow_dispatch` trigger with version override input to `build-extension.yml`
- Created `publish-extension.yml` for automated Marketplace publishing on release
- Documented `VSCE_PAT` secret setup in `PACKAGING.md`

### Issue #8 — Marketplace listing metadata
- Added `keywords`, `galleryBanner`, `bugs`, and `homepage` to `package.template.json`
- Publisher (`coatsy`), icon (`icon.png`), and README already in place from earlier work

### Issue #11 — Marketplace publish workflow
- `publish-extension.yml` triggers on GitHub Release creation and manual `workflow_dispatch`
- Validates release tag matches manifest version
- Supports dry-run mode for testing without publishing
- Uploads VSIX as build artifact

## Testing

- [ ] `workflow_dispatch` trigger appears in the Actions tab for Build Extension
- [ ] Publish Extension workflow appears in the Actions tab
- [ ] Manual dry-run packages without publishing
- [ ] Release creation triggers publish (requires `VSCE_PAT` secret)

## Closes

Closes #5, closes #8, closes #11