### PR TITLE
chore(extension): bump version to 0.1.3

### DIFF
--- a/extension-pack/package.json
+++ b/extension-pack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "copilot-studio-development-bundle",
   "displayName": "Copilot Studio Development Bundle",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Extension pack that installs both the Copilot Studio Skills and Copilot Studio extensions for a complete agent development experience",
   "publisher": "coatsy",
   "repository": {

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.1.3
+
+### Fixed
+
+- Build script now resolves skill-local `${CLAUDE_SKILL_DIR}/` path references (not just `../../` patterns), fixing CI validation failures after upstream merges
+
+### Added
+
+- Upstream sync workflow (`sync-upstream.yml`) that runs weekly to auto-merge changes from `microsoft/skills-for-copilot-studio` main, creating draft PRs or warning on conflicts
+- Dedicated `CLAUDE_SKILL_DIR` resolution check in CI that validates all staged files, not just skills
+
 ## 0.1.2
 
 ### Fixed

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -11,6 +11,29 @@
 - Upstream sync workflow (`sync-upstream.yml`) that runs weekly to auto-merge changes from `microsoft/skills-for-copilot-studio` main, creating draft PRs or warning on conflicts
 - Dedicated `CLAUDE_SKILL_DIR` resolution check in CI that validates all staged files, not just skills
 
+### Upstream Changes
+
+#### Skills
+
+- **`edit-action`** — now supports MCP server actions (`InvokeExternalAgentTaskAction`) in addition to connector actions; adds SharePoint-specific reference (`sharepoint-actions.md`) with OData filter syntax and quoting patterns
+- **`add-action`** — adds MCP server action guidance explaining that MCP connections must be created in the Copilot Studio portal first, plus the new `mcp-action.mcs.yml` template reference
+- **`create-eval`** — new skill for self-service eval authoring with scenario-based testing, SHA-256 snapshots, and HTML reports
+- **`int-reference`** — adds documentation for `$`-prefixed OData property names (SharePoint `$filter`/`$orderby`) with correct quoting patterns for TaskDialog vs InvokeConnectorAction
+
+#### Agents
+
+- **`copilot-studio-author`** — stronger guardrails against creating agent projects from scratch; clearer messaging that `agent.mcs.yml` and `settings.mcs.yml` must not be created, only edited
+
+#### Templates
+
+- **`mcp-action.mcs.yml`** — new template for MCP server actions using `InvokeExternalAgentTaskAction` with `ModelContextProtocolMetadata`
+- **`connector-action.mcs.yml`** — adds `mcs.metadata` format fields
+
+#### Scripts
+
+- Shared auth (`shared-auth.js`) and utilities (`shared-utils.js`) extracted from duplicated script code
+- Updated bundles for `chat-with-agent`, `directline-chat`, and `manage-agent`
+
 ## 0.1.2
 
 ### Fixed

--- a/extension/templates/package.template.json
+++ b/extension/templates/package.template.json
@@ -5,7 +5,7 @@
     "workspace",
     "ui"
   ],
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Copilot Studio YAML authoring, testing, and management skills for GitHub Copilot",
   "publisher": "coatsy",
   "repository": {


### PR DESCRIPTION
## Changes

Bumps extension and extension pack version from 0.1.2 to 0.1.3.

### Changelog additions for 0.1.3

**Fixed**
- Build script now resolves skill-local `${CLAUDE_SKILL_DIR}/` path references (not just `../../` patterns), fixing CI validation failures after upstream merges

**Added**
- Upstream sync workflow (`sync-upstream.yml`) that runs weekly to auto-merge changes from upstream main, creating draft PRs or warning on conflicts
- Dedicated `CLAUDE_SKILL_DIR` resolution check in CI that validates all staged files, not just skills

### Files changed
- `extension/templates/package.template.json` — version 0.1.2 → 0.1.3
- `extension-pack/package.json` — version 0.1.2 → 0.1.3
- `extension/CHANGELOG.md` — added 0.1.3 section