### PR TITLE
chore(extension): bump version to 0.1.4

### DIFF
--- a/extension-pack/package.json
+++ b/extension-pack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "copilot-studio-development-bundle",
   "displayName": "Copilot Studio Development Bundle",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Extension pack that installs both the Copilot Studio Skills and Copilot Studio extensions for a complete agent development experience",
   "publisher": "coatsy",
   "repository": {

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.4
+
+### Fixed
+
+- Updated skills count from 24 to 28 in README, adding missing skills: `chat-directline`, `chat-sdk`, `create-eval`, `detect-mode`, `int-project-context`, `int-reference`
+
 ## 0.1.3
 
 ### Fixed

--- a/extension/templates/package.template.json
+++ b/extension/templates/package.template.json
@@ -5,7 +5,7 @@
     "workspace",
     "ui"
   ],
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Copilot Studio YAML authoring, testing, and management skills for GitHub Copilot",
   "publisher": "coatsy",
   "repository": {


### PR DESCRIPTION
Bumps extension and extension pack version from 0.1.3 to 0.1.4 to publish the updated README with correct skills count (28, not 24) to the Marketplace.