### PR TITLE
feat(workflows): upstream release monitoring and version sync

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,6 +4,8 @@ changelog:
       labels: ["type/feature"]
     - title: "Bug Fixes"
       labels: ["type/fix"]
+    - title: "Upstream Sync"
+      labels: ["upstream/sync"]
     - title: "Documentation"
       labels: ["type/docs"]
     - title: "Infrastructure & Evals"

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -11,6 +11,7 @@ on:
       - 'reference/**'
       - 'extension/**'
       - 'extension-pack/**'
+      - 'upstream-version.json'
       - '.github/workflows/build-extension.yml'
   pull_request:
     branches: [main, coatsy/vscode-extension]
@@ -22,6 +23,7 @@ on:
       - 'reference/**'
       - 'extension/**'
       - 'extension-pack/**'
+      - 'upstream-version.json'
       - '.github/workflows/build-extension.yml'
   workflow_dispatch:
     inputs:

--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -184,13 +184,14 @@ jobs:
         run: |
           TAG="${{ steps.upstream.outputs.tag }}"
 
-          echo "Triggering sync-upstream workflow..."
-          curl -sf \
-            -X POST \
-            -H "Authorization: token $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/sync-upstream.yml/dispatches" \
-            -d '{"ref": "coatsy/vscode-extension"}'
+          echo "Triggering sync-upstream workflow with upstream_version=$TAG..."
+          jq -n --arg tag "$TAG" '{"ref": "coatsy/vscode-extension", "inputs": {"upstream_version": $tag}}' \
+            | curl -sf \
+              -X POST \
+              -H "Authorization: token $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/sync-upstream.yml/dispatches" \
+              -d @-
           echo "Sync-upstream triggered"
 
           echo "Triggering build-extension workflow..."

--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -273,11 +273,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Find open failure issues from previous runs and close them
-          ISSUES=$(curl -sf \
-            -H "Authorization: token $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/issues?state=open&labels=type/infra" \
-            | jq -r '[.[] | select(.title | startswith("ci: check-upstream-release workflow failed"))] | .[].number')
+          ISSUES=$(gh api --paginate \
+            "repos/${{ github.repository }}/issues?state=open&labels=type/infra&per_page=100" \
+            --jq '.[] | select(.title | startswith("ci: check-upstream-release workflow failed")) | .number')
 
           for ISSUE_NUM in $ISSUES; do
             echo "Closing stale failure issue #$ISSUE_NUM"

--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -201,7 +201,18 @@ jobs:
             fs.writeFileSync('extension-pack/package.json', JSON.stringify(pkg, null, 2) + '\n');
           "
 
-          git add upstream-version.json extension/templates/package.template.json extension-pack/package.json
+          # Prepend changelog entry for the new version
+          CHANGELOG="extension/CHANGELOG.md"
+          if [ -f "$CHANGELOG" ]; then
+            RELEASE_BODY=$(cat /tmp/upstream-body.md 2>/dev/null || echo "")
+            ENTRY="## ${VERSION}\n\n### Upstream Sync\n\n- Synced with upstream release [${TAG}](https://github.com/microsoft/skills-for-copilot-studio/releases/tag/${TAG})\n"
+
+            # Insert after the "# Changelog" header
+            sed -i "s/^# Changelog$/# Changelog\n\n${ENTRY}/" "$CHANGELOG"
+            echo "Added changelog entry for ${VERSION}"
+          fi
+
+          git add upstream-version.json extension/templates/package.template.json extension-pack/package.json extension/CHANGELOG.md
           git commit -m "chore: bump version to ${VERSION} (upstream ${TAG})"
           git push origin "$BRANCH"
 
@@ -214,6 +225,7 @@ jobs:
           - \`upstream-version.json\` → \`${TAG}\`
           - \`extension/templates/package.template.json\` → \`${VERSION}\`
           - \`extension-pack/package.json\` → \`${VERSION}\`
+          - \`extension/CHANGELOG.md\` → added \`${VERSION}\` entry
 
           ---
           *This PR was created automatically by the check-upstream-release workflow.*"

--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   issues: write
+  pull-requests: write
 
 jobs:
   check:
@@ -18,6 +19,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: coatsy/vscode-extension
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
 
       - name: Fetch latest upstream release
         id: upstream
@@ -161,21 +168,68 @@ jobs:
 
           echo "Created proposal issue for upstream release $TAG"
 
-      - name: Update tracked version
+      - name: Create version bump branch and PR
         if: steps.compare.outputs.new_release == 'true' && steps.existing.outputs.duplicate == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ steps.upstream.outputs.tag }}"
+          VERSION="${TAG#v}"
           TODAY=$(date -u +%Y-%m-%d)
+          BRANCH="chore/bump-to-${VERSION}"
 
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+
+          # Update upstream-version.json
           jq --arg v "$TAG" --arg d "$TODAY" \
             '.upstream_version = $v | .last_checked = $d' \
             upstream-version.json > tmp.json && mv tmp.json upstream-version.json
 
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add upstream-version.json
-          git commit -m "chore: track upstream release $TAG"
-          git push
+          # Update extension version to match upstream
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('extension/templates/package.template.json', 'utf8'));
+            pkg.version = '$VERSION';
+            fs.writeFileSync('extension/templates/package.template.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('extension-pack/package.json', 'utf8'));
+            pkg.version = '$VERSION';
+            fs.writeFileSync('extension-pack/package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+          git add upstream-version.json extension/templates/package.template.json extension-pack/package.json
+          git commit -m "chore: bump version to ${VERSION} (upstream ${TAG})"
+          git push origin "$BRANCH"
+
+          # Create draft PR
+          PR_BODY="Automated version bump to match upstream release ${TAG}.
+
+          **Upstream release**: [${TAG}](https://github.com/microsoft/skills-for-copilot-studio/releases/tag/${TAG})
+
+          ### Files updated
+          - \`upstream-version.json\` → \`${TAG}\`
+          - \`extension/templates/package.template.json\` → \`${VERSION}\`
+          - \`extension-pack/package.json\` → \`${VERSION}\`
+
+          ---
+          *This PR was created automatically by the check-upstream-release workflow.*"
+
+          curl -sf \
+            -X POST \
+            -H "Authorization: token $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls" \
+            -d "$(jq -n \
+              --arg title "chore: bump version to ${VERSION} (upstream ${TAG})" \
+              --arg body "$PR_BODY" \
+              --arg head "$BRANCH" \
+              '{"title": $title, "body": $body, "head": $head, "base": "coatsy/vscode-extension", "draft": true}')"
+
+          echo "Created version bump PR for ${TAG}"
 
       - name: Trigger upstream sync and build
         if: steps.compare.outputs.new_release == 'true' && steps.existing.outputs.duplicate == 'false'

--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -124,9 +124,9 @@ jobs:
           1. Review the upstream release notes for breaking changes or new features
           2. Run the sync-upstream workflow or manually merge upstream changes
           3. Update `upstream-version.json` to `TAG_PLACEHOLDER`
-          4. Bump extension version as appropriate
+          4. Update extension version to `TAG_PLACEHOLDER` in `extension/templates/package.template.json` and `extension-pack/package.json`
           5. Test the build locally with `bash extension/test-local.sh --package-only`
-          6. Create a release PR
+          6. Create a release tagged `TAG_PLACEHOLDER`
 
           ## Impact Assessment
 

--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -1,0 +1,217 @@
+name: Check upstream release
+
+on:
+  schedule:
+    # Every day at 08:00 UTC
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: coatsy/vscode-extension
+
+      - name: Fetch latest upstream release
+        id: upstream
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RESPONSE=$(curl -sf \
+            -H "Authorization: token $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/microsoft/skills-for-copilot-studio/releases/latest")
+
+          UPSTREAM_TAG=$(echo "$RESPONSE" | jq -r '.tag_name')
+          UPSTREAM_NAME=$(echo "$RESPONSE" | jq -r '.name')
+          UPSTREAM_URL=$(echo "$RESPONSE" | jq -r '.html_url')
+          UPSTREAM_DATE=$(echo "$RESPONSE" | jq -r '.published_at')
+          UPSTREAM_BODY=$(echo "$RESPONSE" | jq -r '.body')
+
+          echo "tag=$UPSTREAM_TAG" >> "$GITHUB_OUTPUT"
+          echo "name=$UPSTREAM_NAME" >> "$GITHUB_OUTPUT"
+          echo "url=$UPSTREAM_URL" >> "$GITHUB_OUTPUT"
+          echo "date=$UPSTREAM_DATE" >> "$GITHUB_OUTPUT"
+
+          # Store body in a file to handle multiline content
+          echo "$UPSTREAM_BODY" > /tmp/upstream-body.md
+
+          echo "Latest upstream release: $UPSTREAM_TAG ($UPSTREAM_DATE)"
+
+      - name: Read tracked version
+        id: tracked
+        run: |
+          if [ ! -f "upstream-version.json" ]; then
+            echo "version=none" >> "$GITHUB_OUTPUT"
+            echo "No upstream-version.json found — treating as first run"
+          else
+            TRACKED=$(jq -r '.upstream_version' upstream-version.json)
+            echo "version=$TRACKED" >> "$GITHUB_OUTPUT"
+            echo "Currently tracked upstream version: $TRACKED"
+          fi
+
+      - name: Compare versions
+        id: compare
+        run: |
+          UPSTREAM="${{ steps.upstream.outputs.tag }}"
+          TRACKED="${{ steps.tracked.outputs.version }}"
+
+          if [ "$UPSTREAM" = "$TRACKED" ]; then
+            echo "new_release=false" >> "$GITHUB_OUTPUT"
+            echo "Already tracking latest upstream version ($UPSTREAM). Nothing to do."
+          else
+            echo "new_release=true" >> "$GITHUB_OUTPUT"
+            echo "New upstream release detected: $UPSTREAM (was: $TRACKED)"
+          fi
+
+      - name: Check for existing proposal issue
+        if: steps.compare.outputs.new_release == 'true'
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.upstream.outputs.tag }}"
+
+          # Search for open issues with the upstream release tag in the title
+          EXISTING=$(curl -sf \
+            -H "Authorization: token $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/issues?state=open&labels=upstream/sync" \
+            | jq -r --arg tag "$TAG" '[.[] | select(.title | contains($tag))] | length')
+
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "duplicate=true" >> "$GITHUB_OUTPUT"
+            echo "Proposal issue for $TAG already exists — skipping."
+          else
+            echo "duplicate=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create proposal issue
+        if: steps.compare.outputs.new_release == 'true' && steps.existing.outputs.duplicate == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.upstream.outputs.tag }}"
+          NAME="${{ steps.upstream.outputs.name }}"
+          URL="${{ steps.upstream.outputs.url }}"
+          DATE="${{ steps.upstream.outputs.date }}"
+          TRACKED="${{ steps.tracked.outputs.version }}"
+          BODY=$(cat /tmp/upstream-body.md)
+
+          ISSUE_BODY=$(cat <<'ISSUE_EOF'
+          ## Upstream Release Detected
+
+          | | |
+          |---|---|
+          | **New upstream version** | `TAG_PLACEHOLDER` |
+          | **Previous tracked version** | `TRACKED_PLACEHOLDER` |
+          | **Published** | DATE_PLACEHOLDER |
+          | **Release URL** | URL_PLACEHOLDER |
+
+          ## Upstream Release Notes
+
+          BODY_PLACEHOLDER
+
+          ## Recommended Actions
+
+          1. Review the upstream release notes for breaking changes or new features
+          2. Run the sync-upstream workflow or manually merge upstream changes
+          3. Update `upstream-version.json` to `TAG_PLACEHOLDER`
+          4. Bump extension version as appropriate
+          5. Test the build locally with `bash extension/test-local.sh --package-only`
+          6. Create a release PR
+
+          ## Impact Assessment
+
+          - [ ] Breaking changes reviewed
+          - [ ] New skills or agents identified
+          - [ ] Extension compatibility verified
+          - [ ] Build tested successfully
+
+          ---
+          *This issue was created automatically by the check-upstream-release workflow.*
+          ISSUE_EOF
+          )
+
+          # Replace placeholders
+          ISSUE_BODY="${ISSUE_BODY//TAG_PLACEHOLDER/$TAG}"
+          ISSUE_BODY="${ISSUE_BODY//TRACKED_PLACEHOLDER/$TRACKED}"
+          ISSUE_BODY="${ISSUE_BODY//DATE_PLACEHOLDER/$DATE}"
+          ISSUE_BODY="${ISSUE_BODY//URL_PLACEHOLDER/$URL}"
+          ISSUE_BODY="${ISSUE_BODY//BODY_PLACEHOLDER/$BODY}"
+
+          # Create the issue via API (avoids shell quoting issues with gh cli)
+          jq -n \
+            --arg title "upstream: new release $TAG available" \
+            --arg body "$ISSUE_BODY" \
+            '{"title": $title, "body": $body, "labels": ["upstream/sync"]}' \
+            | curl -sf \
+              -X POST \
+              -H "Authorization: token $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${{ github.repository }}/issues" \
+              -d @-
+
+          echo "Created proposal issue for upstream release $TAG"
+
+      - name: Update tracked version
+        if: steps.compare.outputs.new_release == 'true' && steps.existing.outputs.duplicate == 'false'
+        run: |
+          TAG="${{ steps.upstream.outputs.tag }}"
+          TODAY=$(date -u +%Y-%m-%d)
+
+          jq --arg v "$TAG" --arg d "$TODAY" \
+            '.upstream_version = $v | .last_checked = $d' \
+            upstream-version.json > tmp.json && mv tmp.json upstream-version.json
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add upstream-version.json
+          git commit -m "chore: track upstream release $TAG"
+          git push
+
+      - name: Trigger upstream sync and build
+        if: steps.compare.outputs.new_release == 'true' && steps.existing.outputs.duplicate == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.upstream.outputs.tag }}"
+
+          echo "Triggering sync-upstream workflow..."
+          curl -sf \
+            -X POST \
+            -H "Authorization: token $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/sync-upstream.yml/dispatches" \
+            -d '{"ref": "coatsy/vscode-extension"}'
+          echo "Sync-upstream triggered"
+
+          echo "Triggering build-extension workflow..."
+          curl -sf \
+            -X POST \
+            -H "Authorization: token $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/build-extension.yml/dispatches" \
+            -d '{"ref": "coatsy/vscode-extension"}'
+          echo "Build triggered successfully"
+
+      - name: Summary
+        run: |
+          TAG="${{ steps.upstream.outputs.tag }}"
+          TRACKED="${{ steps.tracked.outputs.version }}"
+          NEW="${{ steps.compare.outputs.new_release }}"
+
+          echo "### Upstream Release Check :mag:" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| | |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Latest upstream** | \`$TAG\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Tracked version** | \`$TRACKED\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **New release** | $NEW |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -175,7 +175,7 @@ jobs:
           TAG="${{ steps.upstream.outputs.tag }}"
           VERSION="${TAG#v}"
           TODAY=$(date -u +%Y-%m-%d)
-          BRANCH="chore/bump-to-${VERSION}"
+          BRANCH="chore/bump-to-${VERSION}-${TODAY}-${GITHUB_RUN_ID}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -202,6 +202,36 @@ jobs:
             -d '{"ref": "coatsy/vscode-extension"}'
           echo "Build triggered successfully"
 
+      - name: Close stale failure issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Find open failure issues from previous runs and close them
+          ISSUES=$(curl -sf \
+            -H "Authorization: token $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/issues?state=open&labels=type/infra" \
+            | jq -r '[.[] | select(.title | startswith("ci: check-upstream-release workflow failed"))] | .[].number')
+
+          for ISSUE_NUM in $ISSUES; do
+            echo "Closing stale failure issue #$ISSUE_NUM"
+            jq -n \
+              --arg body "Automatically closed — the check-upstream-release workflow succeeded on $(date -u +%Y-%m-%d)." \
+              '{"body": $body}' \
+              | curl -sf \
+                -X POST \
+                -H "Authorization: token $GH_TOKEN" \
+                -H "Accept: application/vnd.github+json" \
+                "https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUM/comments" \
+                -d @-
+            curl -sf \
+              -X PATCH \
+              -H "Authorization: token $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE_NUM" \
+              -d '{"state": "closed", "state_reason": "completed"}'
+          done
+
       - name: Summary
         run: |
           TAG="${{ steps.upstream.outputs.tag }}"

--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -325,12 +325,29 @@ jobs:
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           # Check for an existing open failure issue to avoid duplicates
-          EXISTING=$(curl -sf \
-            -H "Authorization: token $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/issues?state=open&labels=type/infra" \
-            | jq -r '[.[] | select(.title | startswith("ci: check-upstream-release workflow failed"))] | length')
+          EXISTING=0
+          PAGE=1
 
+          while true; do
+            RESPONSE=$(curl -sf \
+              -H "Authorization: token $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${{ github.repository }}/issues?state=open&labels=type/infra&per_page=100&page=$PAGE")
+
+            PAGE_COUNT=$(printf '%s' "$RESPONSE" | jq 'length')
+            if [ "$PAGE_COUNT" -eq 0 ]; then
+              break
+            fi
+
+            MATCHING_COUNT=$(printf '%s' "$RESPONSE" | jq -r '[.[] | select(.title | startswith("ci: check-upstream-release workflow failed"))] | length')
+            EXISTING=$((EXISTING + MATCHING_COUNT))
+
+            if [ "$PAGE_COUNT" -lt 100 ]; then
+              break
+            fi
+
+            PAGE=$((PAGE + 1))
+          done
           if [ "$EXISTING" -gt 0 ]; then
             echo "Failure issue already open — skipping."
             exit 0

--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -86,12 +86,11 @@ jobs:
         run: |
           TAG="${{ steps.upstream.outputs.tag }}"
 
-          # Search for open issues with the upstream release tag in the title
-          EXISTING=$(curl -sf \
-            -H "Authorization: token $GH_TOKEN" \
+          # Search all pages of open issues/PRs with the upstream/sync label
+          EXISTING=$(gh api --paginate \
             -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/issues?state=open&labels=upstream/sync" \
-            | jq -r --arg tag "$TAG" '[.[] | select(.title | contains($tag))] | length')
+            "/repos/${{ github.repository }}/issues?state=open&labels=upstream/sync&per_page=100" \
+            | jq -r -s --arg tag "$TAG" 'add | map(select(.title | contains($tag))) | length')
 
           if [ "$EXISTING" -gt 0 ]; then
             echo "duplicate=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/check-upstream-release.yml
+++ b/.github/workflows/check-upstream-release.yml
@@ -215,3 +215,42 @@ jobs:
           echo "| **Latest upstream** | \`$TAG\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| **Tracked version** | \`$TRACKED\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| **New release** | $NEW |" >> "$GITHUB_STEP_SUMMARY"
+
+  notify-failure:
+    runs-on: ubuntu-latest
+    needs: check
+    if: failure()
+    permissions:
+      issues: write
+    steps:
+      - name: Open failure issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TITLE="ci: check-upstream-release workflow failed ($(date -u +%Y-%m-%d))"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          # Check for an existing open failure issue to avoid duplicates
+          EXISTING=$(curl -sf \
+            -H "Authorization: token $GH_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${{ github.repository }}/issues?state=open&labels=type/infra" \
+            | jq -r '[.[] | select(.title | startswith("ci: check-upstream-release workflow failed"))] | length')
+
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "Failure issue already open — skipping."
+            exit 0
+          fi
+
+          jq -n \
+            --arg title "$TITLE" \
+            --arg body "The daily upstream release check workflow failed.\n\n**Run**: $RUN_URL\n\nPlease investigate the workflow logs and fix the issue.\n\n---\n*This issue was created automatically.*" \
+            '{"title": $title, "body": $body, "labels": ["type/infra"]}' \
+            | curl -sf \
+              -X POST \
+              -H "Authorization: token $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${{ github.repository }}/issues" \
+              -d @-
+
+          echo "Opened failure notification issue"

--- a/.github/workflows/new-release.yml
+++ b/.github/workflows/new-release.yml
@@ -61,9 +61,38 @@ jobs:
           fi
           echo "New version: $NEW_VERSION"
 
-          # Update both version files
+          # Update Claude plugin version files
           jq --arg v "$NEW_VERSION" '.version = $v' .claude-plugin/plugin.json > tmp.json && mv tmp.json .claude-plugin/plugin.json
           jq --arg v "$NEW_VERSION" '.plugins[0].version = $v' .claude-plugin/marketplace.json > tmp.json && mv tmp.json .claude-plugin/marketplace.json
+
+          # Update VS Code extension version files to match upstream
+          if [ -f "extension/templates/package.template.json" ]; then
+            node -e "
+              const fs = require('fs');
+              const pkg = JSON.parse(fs.readFileSync('extension/templates/package.template.json', 'utf8'));
+              pkg.version = '$NEW_VERSION';
+              fs.writeFileSync('extension/templates/package.template.json', JSON.stringify(pkg, null, 2) + '\n');
+            "
+            echo "Updated extension/templates/package.template.json to $NEW_VERSION"
+          fi
+          if [ -f "extension-pack/package.json" ]; then
+            node -e "
+              const fs = require('fs');
+              const pkg = JSON.parse(fs.readFileSync('extension-pack/package.json', 'utf8'));
+              pkg.version = '$NEW_VERSION';
+              fs.writeFileSync('extension-pack/package.json', JSON.stringify(pkg, null, 2) + '\n');
+            "
+            echo "Updated extension-pack/package.json to $NEW_VERSION"
+          fi
+
+          # Update upstream-version.json if present
+          if [ -f "upstream-version.json" ]; then
+            TODAY=$(date -u +%Y-%m-%d)
+            jq --arg v "v$NEW_VERSION" --arg d "$TODAY" \
+              '.upstream_version = $v | .last_checked = $d' \
+              upstream-version.json > tmp.json && mv tmp.json upstream-version.json
+            echo "Updated upstream-version.json to v$NEW_VERSION"
+          fi
 
           # Configure git
           git config user.name "github-actions[bot]"
@@ -71,7 +100,7 @@ jobs:
 
           # Create branch, commit, and push
           git checkout -b "$BRANCH"
-          git add .claude-plugin/plugin.json .claude-plugin/marketplace.json
+          git add -A
           git commit -m "chore: bump version to ${NEW_VERSION} for ${BRANCH}"
           git push origin "$BRANCH"
 

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -53,6 +53,24 @@ jobs:
             exit 1
           fi
 
+      - name: Validate upstream version tracking
+        if: github.event_name == 'release'
+        run: |
+          if [ ! -f "upstream-version.json" ]; then
+            echo "ERROR: upstream-version.json not found. See VERSIONING.md for policy."
+            exit 1
+          fi
+          UPSTREAM_VERSION=$(node -e "
+            const uv = require('./upstream-version.json');
+            console.log(uv.upstream_version || '');
+          ")
+          if [ -z "$UPSTREAM_VERSION" ]; then
+            echo "ERROR: upstream-version.json does not contain a valid upstream_version"
+            exit 1
+          fi
+          echo "UPSTREAM_VERSION=$UPSTREAM_VERSION" >> "$GITHUB_ENV"
+          echo "Upstream version tracked: $UPSTREAM_VERSION"
+
       - name: Build skills extension VSIX
         run: bash extension/test-local.sh --package-only
         env:
@@ -102,6 +120,29 @@ jobs:
       - name: Dry-run notice
         if: github.event_name == 'workflow_dispatch' && inputs.dry_run == true
         run: echo "Dry run \u2014 both VSIX files built but not published."
+
+      - name: Append upstream version to release body
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RELEASE_TAG="${{ github.event.release.tag_name }}"
+          CURRENT_BODY=$(echo '${{ toJSON(github.event.release.body) }}' | jq -r '.')
+          UPSTREAM_REF="\n---\n**Upstream version**: [${UPSTREAM_VERSION}](https://github.com/microsoft/skills-for-copilot-studio/releases/tag/${UPSTREAM_VERSION})"
+
+          # Only append if not already present
+          if echo "$CURRENT_BODY" | grep -q "Upstream version"; then
+            echo "Upstream version reference already present — skipping."
+          else
+            NEW_BODY="${CURRENT_BODY}${UPSTREAM_REF}"
+            jq -n --arg body "$NEW_BODY" '{"body": $body}' | curl -sf \
+              -X PATCH \
+              -H "Authorization: token $GH_TOKEN" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${{ github.repository }}/releases/${{ github.event.release.id }}" \
+              -d @-
+            echo "Appended upstream version ($UPSTREAM_VERSION) to release notes"
+          fi
 
       - name: Upload skills extension VSIX
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -62,7 +62,8 @@ jobs:
           fi
           UPSTREAM_VERSION=$(node -e "
             const uv = require('./upstream-version.json');
-            console.log(uv.upstream_version || '');
+            const v = uv.upstream_version || '';
+            console.log(v.replace(/^v/, ''));
           ")
           if [ -z "$UPSTREAM_VERSION" ]; then
             echo "ERROR: upstream-version.json does not contain a valid upstream_version"
@@ -70,6 +71,13 @@ jobs:
           fi
           echo "UPSTREAM_VERSION=$UPSTREAM_VERSION" >> "$GITHUB_ENV"
           echo "Upstream version tracked: $UPSTREAM_VERSION"
+
+          # Enforce synchronized versioning: extension version must match upstream
+          if [ "$SKILLS_VERSION" != "$UPSTREAM_VERSION" ]; then
+            echo "ERROR: Extension version ($SKILLS_VERSION) does not match upstream version ($UPSTREAM_VERSION)"
+            echo "See VERSIONING.md — this fork's version must match the upstream release version."
+            exit 1
+          fi
 
       - name: Build skills extension VSIX
         run: bash extension/test-local.sh --package-only

--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -135,7 +135,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           RELEASE_TAG="${{ github.event.release.tag_name }}"
-          CURRENT_BODY=$(echo '${{ toJSON(github.event.release.body) }}' | jq -r '.')
+          CURRENT_BODY=$(jq -r '.release.body // ""' "$GITHUB_EVENT_PATH")
           UPSTREAM_REF="\n---\n**Upstream version**: [${UPSTREAM_VERSION}](https://github.com/microsoft/skills-for-copilot-studio/releases/tag/${UPSTREAM_VERSION})"
 
           # Only append if not already present

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -68,15 +68,33 @@ jobs:
 
           git push origin "$BRANCH"
 
+          # Build PR body with optional upstream version reference
+          UPSTREAM_VERSION="${{ inputs.upstream_version }}"
+          if [ -n "$UPSTREAM_VERSION" ]; then
+            VERSION_LINE="**Upstream release**: [$UPSTREAM_VERSION](https://github.com/microsoft/skills-for-copilot-studio/releases/tag/$UPSTREAM_VERSION)"
+          else
+            VERSION_LINE=""
+          fi
+
+          PR_BODY="Automated sync of upstream microsoft/skills-for-copilot-studio main into coatsy/vscode-extension.
+
+          **Commits behind**: $BEHIND"
+
+          if [ -n "$VERSION_LINE" ]; then
+            PR_BODY="$PR_BODY
+          $VERSION_LINE"
+          fi
+
+          PR_BODY="$PR_BODY
+
+          This PR was created automatically by the sync-upstream workflow."
+
           gh pr create \
             --base coatsy/vscode-extension \
             --head "$BRANCH" \
-            --title "chore: sync $BEHIND commit(s) from upstream main" \
-            --body "Automated sync of upstream microsoft/skills-for-copilot-studio main into coatsy/vscode-extension.
-
-          **Commits behind**: $BEHIND
-
-          This PR was created automatically by the sync-upstream workflow." \
+            --title "chore: sync $BEHIND commit(s) from upstream main${UPSTREAM_VERSION:+ ($UPSTREAM_VERSION)}" \
+            --body "$PR_BODY" \
+            --label "upstream/sync" \
             --draft
 
       - name: Report conflict

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -11,6 +11,11 @@ on:
         required: false
         type: string
   workflow_dispatch:
+    inputs:
+      upstream_version:
+        description: "Upstream version that triggered this sync (leave empty for scheduled runs)"
+        required: false
+        type: string
 
 permissions:
   contents: write

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     # Every Monday at 06:00 UTC
     - cron: "0 6 * * 1"
+  workflow_call:
+    inputs:
+      upstream_version:
+        description: "Upstream version that triggered this sync (set by check-upstream-release)"
+        required: false
+        type: string
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/validate-versions.yml
+++ b/.github/workflows/validate-versions.yml
@@ -1,0 +1,63 @@
+name: Validate version consistency
+
+on:
+  pull_request:
+    branches: [coatsy/vscode-extension]
+    paths:
+      - 'extension/templates/package.template.json'
+      - 'extension-pack/package.json'
+      - 'upstream-version.json'
+
+jobs:
+  check-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate version files are in sync
+        run: |
+          SKILLS_VERSION=$(node -e "
+            const pkg = require('./extension/templates/package.template.json');
+            console.log(pkg.version);
+          ")
+          BUNDLE_VERSION=$(node -e "
+            const pkg = require('./extension-pack/package.json');
+            console.log(pkg.version);
+          ")
+
+          echo "Skills extension version: $SKILLS_VERSION"
+          echo "Extension pack version:   $BUNDLE_VERSION"
+
+          ERRORS=0
+
+          # Check extension versions match each other
+          if [ "$SKILLS_VERSION" != "$BUNDLE_VERSION" ]; then
+            echo "::error::Skills extension version ($SKILLS_VERSION) does not match extension pack version ($BUNDLE_VERSION)"
+            ERRORS=$((ERRORS + 1))
+          fi
+
+          # Check versions match upstream-version.json if present
+          if [ -f "upstream-version.json" ]; then
+            UPSTREAM_VERSION=$(node -e "
+              const uv = require('./upstream-version.json');
+              const v = uv.upstream_version || '';
+              console.log(v.replace(/^v/, ''));
+            ")
+            echo "Upstream version:         $UPSTREAM_VERSION"
+
+            if [ -n "$UPSTREAM_VERSION" ] && [ "$SKILLS_VERSION" != "$UPSTREAM_VERSION" ]; then
+              echo "::error::Extension version ($SKILLS_VERSION) does not match upstream version ($UPSTREAM_VERSION). See VERSIONING.md."
+              ERRORS=$((ERRORS + 1))
+            fi
+          fi
+
+          if [ "$ERRORS" -gt 0 ]; then
+            echo ""
+            echo "Version files are out of sync. All version files must match:"
+            echo "  - extension/templates/package.template.json"
+            echo "  - extension-pack/package.json"
+            echo "  - upstream-version.json (upstream_version, without 'v' prefix)"
+            exit 1
+          fi
+
+          echo "All version files are in sync ($SKILLS_VERSION)"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ description: "Author, test, and troubleshoot Microsoft Copilot Studio agents thr
 
 A toolkit for authoring, testing, and troubleshooting [Microsoft Copilot Studio](https://aka.ms/CopilotStudio) agents through YAML files. Available as a VS Code extension for GitHub Copilot Chat and as a plugin for [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
 
+[![Upstream Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fcoatsy%2Fskills-for-copilot-studio%2Fcoatsy%2Fvscode-extension%2Fupstream-version.json&query=%24.upstream_version&label=upstream&color=blue)](https://github.com/microsoft/skills-for-copilot-studio/releases)
+
 ## Prerequisites
 
 * [Node.js](https://nodejs.org/) 22+

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,24 +1,26 @@
 # Versioning Policy
 
-This document defines the version mapping between this fork's VS Code extension
-releases and the upstream [microsoft/skills-for-copilot-studio](https://github.com/microsoft/skills-for-copilot-studio) releases.
+This document defines the version synchronization between this fork's VS Code
+extension releases and the upstream
+[microsoft/skills-for-copilot-studio](https://github.com/microsoft/skills-for-copilot-studio)
+releases.
 
-## Extension Versioning
+## Synchronized Versioning
 
-The VS Code extension uses its own independent semver version (MAJOR.MINOR.PATCH)
-defined in `extension/templates/package.template.json` and `extension-pack/package.json`.
+This fork's extension version **matches the upstream release version**. When
+upstream publishes `v1.0.8`, this fork's extension is also released as `v1.0.8`.
 
-| Bump      | When                                                      |
-|-----------|-----------------------------------------------------------|
-| **Patch** | Bug fixes, docs, dependency updates, upstream sync        |
-| **Minor** | New extension features, new skills, new agent definitions |
-| **Major** | Breaking changes to extension API or skill interface       |
+The version is maintained in two places:
+
+- `extension/templates/package.template.json` — VS Code skills extension
+- `extension-pack/package.json` — VS Code extension pack bundle
+
+Both must always match the upstream version tracked in `upstream-version.json`.
 
 ## Upstream Version Tracking
 
-Each release of this extension tracks which upstream release it aligns with.
-The tracked upstream version is stored in `upstream-version.json` at the
-repository root.
+The current upstream version is stored in `upstream-version.json` at the
+repository root:
 
 ```json
 {
@@ -28,24 +30,13 @@ repository root.
 }
 ```
 
-## Version Mapping
-
-This fork's version numbers are **independent** from upstream. The mapping is:
-
-| This Fork | Upstream | Relationship |
-|-----------|----------|--------------|
-| `v0.1.x`  | `v1.0.x`  | Fork extension built on upstream skills content |
-
-The `upstream-version.json` file provides the authoritative mapping between
-any fork release and the upstream version it incorporates.
-
 ## Release Workflow Guards
 
 The following guards enforce the versioning policy:
 
-1. **Upstream version reference** — The `publish-extension.yml` workflow
-   validates that `upstream-version.json` exists and contains a valid upstream
-   version before publishing.
+1. **Version match** — The `publish-extension.yml` workflow validates that the
+   extension version matches the upstream version in `upstream-version.json`
+   before publishing. A release will fail if versions are out of sync.
 
 2. **Release notes** — Every release includes the upstream version reference
    so users can identify compatibility.
@@ -53,13 +44,14 @@ The following guards enforce the versioning policy:
 3. **Daily monitor** — The `check-upstream-release.yml` workflow detects new
    upstream releases and opens a proposal issue with the recommended action.
 
-## How to Update the Upstream Version
+## How to Update When a New Upstream Release Is Detected
 
-When a new upstream release is detected (via the daily monitor or manual check):
+When the daily monitor detects a new upstream release (e.g. `v1.0.9`):
 
 1. Review the upstream release notes and assess impact.
 2. Sync upstream changes using the `sync-upstream.yml` workflow or manually.
-3. Update `upstream-version.json` with the new upstream version and date.
-4. Bump the extension version as appropriate (patch for upstream sync, minor
-   for new features).
-5. Create a release following the normal release process.
+3. Update `upstream-version.json` with the new version and date.
+4. Update `extension/templates/package.template.json` version to `1.0.9`.
+5. Update `extension-pack/package.json` version to `1.0.9`.
+6. Test the build locally with `bash extension/test-local.sh --package-only`.
+7. Create a release tagged `v1.0.9`.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,65 @@
+# Versioning Policy
+
+This document defines the version mapping between this fork's VS Code extension
+releases and the upstream [microsoft/skills-for-copilot-studio](https://github.com/microsoft/skills-for-copilot-studio) releases.
+
+## Extension Versioning
+
+The VS Code extension uses its own independent semver version (MAJOR.MINOR.PATCH)
+defined in `extension/templates/package.template.json` and `extension-pack/package.json`.
+
+| Bump      | When                                                      |
+|-----------|-----------------------------------------------------------|
+| **Patch** | Bug fixes, docs, dependency updates, upstream sync        |
+| **Minor** | New extension features, new skills, new agent definitions |
+| **Major** | Breaking changes to extension API or skill interface       |
+
+## Upstream Version Tracking
+
+Each release of this extension tracks which upstream release it aligns with.
+The tracked upstream version is stored in `upstream-version.json` at the
+repository root.
+
+```json
+{
+  "upstream_repo": "microsoft/skills-for-copilot-studio",
+  "upstream_version": "v1.0.8",
+  "last_checked": "2026-04-23"
+}
+```
+
+## Version Mapping
+
+This fork's version numbers are **independent** from upstream. The mapping is:
+
+| This Fork | Upstream | Relationship |
+|-----------|----------|--------------|
+| `v0.1.x`  | `v1.0.x`  | Fork extension built on upstream skills content |
+
+The `upstream-version.json` file provides the authoritative mapping between
+any fork release and the upstream version it incorporates.
+
+## Release Workflow Guards
+
+The following guards enforce the versioning policy:
+
+1. **Upstream version reference** — The `publish-extension.yml` workflow
+   validates that `upstream-version.json` exists and contains a valid upstream
+   version before publishing.
+
+2. **Release notes** — Every release includes the upstream version reference
+   so users can identify compatibility.
+
+3. **Daily monitor** — The `check-upstream-release.yml` workflow detects new
+   upstream releases and opens a proposal issue with the recommended action.
+
+## How to Update the Upstream Version
+
+When a new upstream release is detected (via the daily monitor or manual check):
+
+1. Review the upstream release notes and assess impact.
+2. Sync upstream changes using the `sync-upstream.yml` workflow or manually.
+3. Update `upstream-version.json` with the new upstream version and date.
+4. Bump the extension version as appropriate (patch for upstream sync, minor
+   for new features).
+5. Create a release following the normal release process.

--- a/extension-pack/package.json
+++ b/extension-pack/package.json
@@ -1,7 +1,7 @@
 {
   "name": "copilot-studio-development-bundle",
   "displayName": "Copilot Studio Development Bundle",
-  "version": "0.1.4",
+  "version": "1.0.8",
   "description": "Extension pack that installs both the Copilot Studio Skills and Copilot Studio extensions for a complete agent development experience",
   "publisher": "coatsy",
   "repository": {

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.0.8
+
+### Changed
+
+- Synchronized extension version with upstream microsoft/skills-for-copilot-studio releases (previously independent at 0.1.x)
+- Added daily upstream release monitoring workflow
+- Added upstream version badge to README
+- Added version synchronization guards to publish workflow
+
 ## 0.1.4
 
 ### Fixed

--- a/extension/templates/package.template.json
+++ b/extension/templates/package.template.json
@@ -5,7 +5,7 @@
     "workspace",
     "ui"
   ],
-  "version": "0.1.4",
+  "version": "1.0.8",
   "description": "Copilot Studio YAML authoring, testing, and management skills for GitHub Copilot",
   "publisher": "coatsy",
   "repository": {

--- a/upstream-version.json
+++ b/upstream-version.json
@@ -1,0 +1,6 @@
+{
+  "upstream_repo": "microsoft/skills-for-copilot-studio",
+  "upstream_version": "v1.0.8",
+  "last_checked": "2026-04-23",
+  "notes": "Tracked by check-upstream-release workflow. Updated when a new upstream release is detected and processed."
+}


### PR DESCRIPTION
## Summary

Add automated daily monitoring of upstream microsoft/skills-for-copilot-studio releases, synchronized version numbering, and release automation infrastructure.

Closes #29
Closes #30

## Changes

### New Files
- `.github/workflows/check-upstream-release.yml` — Daily scheduled workflow that:
  - Checks for new upstream releases via GitHub API
  - Creates proposal issues with impact assessment checklists
  - Creates draft PRs that bump version in all manifests to match upstream
  - Triggers sync-upstream and build-extension workflows
  - Auto-closes stale failure notification issues
  - Opens failure notification issues when the workflow fails
- `upstream-version.json` — Tracks the currently aligned upstream version (v1.0.8)
- `VERSIONING.md` — Documents the synchronized versioning policy

### Modified Files
- `.github/workflows/publish-extension.yml` — Added upstream version validation guard enforcing extension version matches upstream, and auto-injection of upstream version into release notes body
- `.github/workflows/sync-upstream.yml` — Added `workflow_call` and `workflow_dispatch` inputs for `upstream_version`; enhanced PR title/body to include upstream version; added `upstream/sync` label
- `.github/workflows/new-release.yml` — Now also bumps `package.template.json`, `extension-pack/package.json`, and `upstream-version.json` alongside Claude plugin files
- `.github/release.yml` — Added `Upstream Sync` category with `upstream/sync` label
- `README.md` — Added dynamic upstream version badge
- `extension/templates/package.template.json` — Version synchronized from `0.1.4` to `1.0.8`
- `extension-pack/package.json` — Version synchronized from `0.1.4` to `1.0.8`
- `extension/CHANGELOG.md` — Added `1.0.8` entry for version alignment

## Versioning Policy

This fork's extension version now **matches the upstream release version**. When upstream publishes `v1.0.9`, this fork's extension is also released as `v1.0.9`. The publish workflow enforces this — a release will fail if the extension version doesn't match `upstream-version.json`.

## Acceptance Criteria Coverage

### Issue #29 — Daily monitoring
- ✅ Daily scheduled check (cron: `0 8 * * *`)
- ✅ `workflow_dispatch` for manual ad-hoc checks
- ✅ Duplicate proposal prevention via label search
- ✅ Proposal includes upstream release link, change summary, and impact checklist
- ✅ Failure visibility via auto-created issues with `type/infra` label
- ✅ Auto-close stale failure issues on successful run
- ✅ Triggers both sync-upstream and build-extension workflows
- ✅ Creates draft version bump PR automatically

### Issue #30 — Version sync
- ✅ Synchronized versioning policy documented in VERSIONING.md
- ✅ Extension version bumped to match upstream (1.0.8)
- ✅ Publish workflow enforces extension version == upstream version
- ✅ Release notes auto-injected with upstream version reference
- ✅ upstream/sync release notes category added
- ✅ new-release workflow bumps all version files together